### PR TITLE
Ipv4 nonprivate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 !gradle/wrapper/gradle-wrapper.jar
 .idea/*
 build/*
+/bin/
+.classpath
+.project
+.settings/

--- a/src/main/java/net/andreinc/mockneat/types/enums/IPv4Type.java
+++ b/src/main/java/net/andreinc/mockneat/types/enums/IPv4Type.java
@@ -24,27 +24,39 @@ public enum IPv4Type {
     CLASS_A (new Range<>(1, 126), new Range<>(0, 255), new Range<>(0, 255), new Range<>(0, 255)),
     CLASS_A_LOOPBACK (new Range<>(127, 127), new Range<>(0, 255), new Range<>(0, 255), new Range<>(0, 255)),
     CLASS_A_PRIVATE (new Range<>(10, 10), new Range<>(0, 255), new Range<>(0, 255), new Range<>(0, 255)),
+    CLASS_A_NONPRIVATE (new Range<>(1, 126), new Range<>(0, 255), new Range<>(0, 255), new Range<>(0, 255), false),
     CLASS_B (new Range<>(128, 191), new Range<>(0, 255), new Range<>(0, 255), new Range<>(0, 255)),
     CLASS_B_PRIVATE (new Range<>(172, 172), new Range<>(16, 31), new Range<>(0, 255), new Range<>(0, 255)),
+    CLASS_B_NONPRIVATE (new Range<>(128, 191), new Range<>(0, 255), new Range<>(0, 255), new Range<>(0, 255), false),
     CLASS_C (new Range<>(192, 223), new Range<>(0, 255), new Range<>(0, 255), new Range<>(0, 255)),
     CLASS_C_PRIVATE (new Range<>(192, 192), new Range<>(168, 168), new Range<>(0, 255), new Range<>(0, 255)),
+    CLASS_C_NONPRIVATE (new Range<>(192, 223), new Range<>(0, 255), new Range<>(0, 255), new Range<>(0, 255), false),
     CLASS_D (new Range<>(224, 239), new Range<>(0, 255), new Range<>(0, 255), new Range<>(0, 255)),
     CLASS_E (new Range<>(240, 254), new Range<>(0, 255), new Range<>(0, 255), new Range<>(0, 255)),
     NO_CONSTRAINT(new Range<>(0, 255), new Range<>(0, 255), new Range<>(0, 255), new Range<>(0, 255));
 
     private final Range<Integer>[] octets;
+    private final boolean privateAllowed;
 
-    IPv4Type(Range<Integer> o1, Range<Integer> o2, Range<Integer> o3, Range<Integer> o4) {
+    IPv4Type(Range<Integer> o1, Range<Integer> o2, Range<Integer> o3, Range<Integer> o4, boolean privateAllowed) {
         this.octets = (Range<Integer>[]) new Range[4];
         this.octets[0] = o1;
         this.octets[1] = o2;
         this.octets[2] = o3;
         this.octets[3] = o4;
+        this.privateAllowed = privateAllowed;
+    }
+    
+    IPv4Type(Range<Integer> o1, Range<Integer> o2, Range<Integer> o3, Range<Integer> o4){
+        this(o1,o2,o3,o4,true);
     }
 
     public Range<Integer>[] getOctets() {
         return octets;
     }
 
+    public boolean isPrivateAllowed() {
+        return privateAllowed;
+    }
 
 }

--- a/src/main/java/net/andreinc/mockneat/unit/networking/IPv4s.java
+++ b/src/main/java/net/andreinc/mockneat/unit/networking/IPv4s.java
@@ -1,5 +1,14 @@
 package net.andreinc.mockneat.unit.networking;
 
+import static java.util.stream.Collectors.toList;
+import static net.andreinc.mockneat.types.enums.IPv4Type.NO_CONSTRAINT;
+import static net.andreinc.mockneat.utils.ValidationUtils.notEmptyOrNullValues;
+import static net.andreinc.mockneat.utils.ValidationUtils.notNull;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Supplier;
+
 /**
  * Copyright 2017, Andrei N. Ciobanu
 
@@ -22,13 +31,6 @@ import net.andreinc.mockneat.abstraction.MockUnitBase;
 import net.andreinc.mockneat.abstraction.MockUnitString;
 import net.andreinc.mockneat.types.Range;
 import net.andreinc.mockneat.types.enums.IPv4Type;
-
-import java.util.Arrays;
-import java.util.function.Supplier;
-
-import static net.andreinc.mockneat.types.enums.IPv4Type.NO_CONSTRAINT;
-import static net.andreinc.mockneat.utils.ValidationUtils.notEmptyOrNullValues;
-import static net.andreinc.mockneat.utils.ValidationUtils.notNull;
 
 public class IPv4s extends MockUnitBase implements MockUnitString {
 
@@ -62,9 +64,23 @@ public class IPv4s extends MockUnitBase implements MockUnitString {
                 }
             });
             buff.deleteCharAt(buff.length() - 1);
-            return buff.toString();
+            String result = buff.toString();
+            return type.isPrivateAllowed() || !isPrivate(result) ? result : type(type).val() ;
         };
         return () -> supp;
+    }
+    
+    private boolean isPrivate(String ip) {
+        List<Integer> numbers = 
+                Arrays.stream(ip.split("\\."))
+                    .map(Integer::parseInt)
+                    .collect(toList());
+        return (
+                numbers.get(0) == 10 ||
+                (numbers.get(0) == 172 && numbers.get(1) >= 16 && numbers.get(1) < 32) ||
+                (numbers.get(0) == 192 && numbers.get(1) == 168)
+        );
+            
     }
 
 }

--- a/src/test/java/net/andreinc/mockneat/unit/networking/IPv4sTest.java
+++ b/src/test/java/net/andreinc/mockneat/unit/networking/IPv4sTest.java
@@ -52,6 +52,14 @@ public class IPv4sTest {
             }
         }
         
+        if(Arrays.stream(new IPv4Type[] {IPv4Type.CLASS_A_NONPRIVATE, IPv4Type.CLASS_B_NONPRIVATE, IPv4Type.CLASS_C_NONPRIVATE}).anyMatch(x -> x == type)) {
+            try {
+                assertTrue(!isPrivate(ip));
+            }catch(UnknownHostException e) {
+                fail(e.getMessage());
+            }
+        }
+        
         
         Range<Integer>[] bounds = type.getOctets();
         assertTrue(bounds.length == 4);

--- a/src/test/java/net/andreinc/mockneat/unit/networking/IPv4sTest.java
+++ b/src/test/java/net/andreinc/mockneat/unit/networking/IPv4sTest.java
@@ -24,6 +24,9 @@ import net.andreinc.mockneat.types.enums.IPv4Type;
 import org.apache.commons.validator.routines.InetAddressValidator;
 import org.junit.Test;
 
+import java.net.Inet4Address;
+import java.net.UnknownHostException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -40,7 +43,17 @@ public class IPv4sTest {
     private static final InetAddressValidator IAV = new InetAddressValidator();
 
     protected void testIp(String ip, IPv4Type type) {
-        Range[] bounds = type.getOctets();
+        
+        if(Arrays.stream(new IPv4Type[] {IPv4Type.CLASS_A_PRIVATE, IPv4Type.CLASS_B_PRIVATE, IPv4Type.CLASS_C_PRIVATE}).anyMatch(x -> x == type)) {
+            try {
+                assertTrue(isPrivate(ip));
+            }catch(UnknownHostException e) {
+                fail(e.getMessage());
+            }
+        }
+        
+        
+        Range<Integer>[] bounds = type.getOctets();
         assertTrue(bounds.length == 4);
 
         try {
@@ -66,6 +79,11 @@ public class IPv4sTest {
 
     protected void testIpCycle(IPv4Type t) {
         loop(Constants.IPV4S_CYCLES, Constants.MOCKS, r -> r.ipv4s().type(t).val(), ip -> testIp(ip, t));
+    }
+    
+    protected boolean isPrivate(String ip) throws UnknownHostException {
+        Inet4Address addr = (Inet4Address) Inet4Address.getByName(ip);
+        return addr.isSiteLocalAddress();
     }
 
     @Test


### PR DESCRIPTION
Add nonprivate ipv4 types as discussed in [issue 18](https://github.com/nomemory/mockneat/issues/18).

`CLASS_A_NONPRIVATE, CLASS_B_NONPRIVATE, CLASS_C_NONPRIVATE `ensure that returned ips won't be private.
The chance of having private ips not being big, we just check in `net.andreinc.mockneat.unit.networking.IPv4s.type()` and regenerate if necessary.

Also test for private/no private ips in `net.andreinc.mockneat.unit.networking.IPv4sTest` accordingly.