### PR TITLE
Bump gradle-bintray-plugin from 1.8.4 to 1.8.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript() {
         jcenter()
     }
     dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
     }
 }
 


### PR DESCRIPTION
Bumps gradle-bintray-plugin from 1.8.4 to 1.8.5.

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>