### PR TITLE
fix: UUIDs always return same uuid

### DIFF
--- a/src/main/java/net/andreinc/mockneat/unit/id/UUIDs.java
+++ b/src/main/java/net/andreinc/mockneat/unit/id/UUIDs.java
@@ -16,7 +16,7 @@ public class UUIDs extends MockUnitBase implements MockUnitString {
 
     @Override
     public Supplier<String> supplier() {
-       return UUID.randomUUID()::toString;
+       return ()->UUID.randomUUID().toString();
     }
 
 }


### PR DESCRIPTION
fix: UUIDs always return same uuid